### PR TITLE
create storage-api.dart (SDV-332)

### DIFF
--- a/protos/lib/storage-api.dart
+++ b/protos/lib/storage-api.dart
@@ -1,0 +1,8 @@
+library storage_api;
+
+export 'src/generated/storage_api.pb.dart';
+export 'src/generated/storage_api.pbenum.dart';
+export 'src/generated/storage_api.pbserver.dart';
+export 'src/generated/storage_api.pbjson.dart';
+
+export 'package:grpc/grpc.dart';


### PR DESCRIPTION
Chore: storage-api.dart was created in protos/lib and the necessary export commands were included. 