### PR TITLE
feat: integrate Units/Users/Initialization (SDV354, 364, 365, 366, 367) + Test fix

### DIFF
--- a/lib/core/constants/vss_path.dart
+++ b/lib/core/constants/vss_path.dart
@@ -51,6 +51,10 @@ class VSSPath {
       'Vehicle.Cabin.Infotainment.HMI.TemperatureUnit';
   static const String vehicleHmiPressureUnit =
       'Vehicle.Cabin.Infotainment.HMI.TirePressureUnit';
+  static const String vehicleCurrentUser = 
+      'Vehicle.Users.selectedUser';
+  static const String vehicleUsers = 
+      'Vehicle.Users';
 
   List<String> getSignalsList() {
     return const [

--- a/lib/data/data_providers/app_provider.dart
+++ b/lib/data/data_providers/app_provider.dart
@@ -143,9 +143,9 @@ final playControllerProvider = Provider((ref) {
   return PlayController(ref: ref);
 });
 
-final usersProvider = StateNotifierProvider<UsersNotifier, Users>((ref) {
-  return UsersNotifier(Users.initial());
-});
+//new userProvider (makes it easier to access other providers)
+final usersProvider =
+    NotifierProvider<UsersNotifier, Users>(UsersNotifier.new);
 
 final hybridStateProvider =
     StateNotifierProvider<HybridNotifier, Hybrid>((ref) {

--- a/lib/data/data_providers/initializeSettings.dart
+++ b/lib/data/data_providers/initializeSettings.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_ics_homescreen/export.dart';
+
+
+Future<void> initializeSettings(ProviderContainer container) async {
+  await container.read(usersProvider.notifier).loadSettingsUsers();
+  await container.read(unitStateProvider.notifier).loadSettingsUnits();
+  // Initialize other settings or providers if needed
+}
+
+Future<void> initializeSettingsUser(Ref ref) async {
+  await ref.read(unitStateProvider.notifier).loadSettingsUnits();
+  // Initialize other settings or providers if needed
+}
+

--- a/lib/data/data_providers/units_notifier.dart
+++ b/lib/data/data_providers/units_notifier.dart
@@ -1,10 +1,40 @@
 import 'package:flutter_ics_homescreen/export.dart';
 import 'package:protos/val-api.dart';
 
+import 'package:protos/storage-api.dart' as storage_api; 
+
 class UnitsNotifier extends Notifier<Units> {
   @override
   Units build() {
     return const Units.initial();
+  }
+
+Future <void> loadSettingsUnits() async{ 
+    final storageClient = ref.read(storageClientProvider);
+    final userClient = ref.read(usersProvider);
+    try {
+      final distanceResponse = await storageClient.read(storage_api.Key(key: VSSPath.vehicleHmiDistanceUnit, namespace: userClient.selectedUser.id));
+      final temperatureResponse = await storageClient.read(storage_api.Key(key: VSSPath.vehicleHmiTemperatureUnit, namespace: userClient.selectedUser.id));
+      final pressureResponse = await storageClient.read(storage_api.Key(key: VSSPath.vehicleHmiPressureUnit, namespace: userClient.selectedUser.id));
+
+      // Default values
+      final distanceUnit = distanceResponse.result == 'MILES'
+          ? DistanceUnit.miles
+          : DistanceUnit.kilometers;
+
+      final temperatureUnit = temperatureResponse.result == 'F'
+          ? TemperatureUnit.fahrenheit
+          : TemperatureUnit.celsius;
+
+      final pressureUnit = pressureResponse.result == 'PSI'
+          ? PressureUnit.psi
+          : PressureUnit.kilopascals;
+
+      state =  Units(distanceUnit, temperatureUnit, pressureUnit);
+    } catch (e) {
+      print('Error loading settings for units: $e');
+      state =  const Units.initial(); // Fallback to initial defaults if error
+    }
   }
 
   bool handleSignalUpdate(DataEntry entry) {
@@ -40,7 +70,7 @@ class UnitsNotifier extends Notifier<Units> {
     return handled;
   }
 
-  void setDistanceUnit(DistanceUnit unit) {
+  Future <void> setDistanceUnit(DistanceUnit unit) async {
     state = state.copyWith(distanceUnit: unit);
     var valClient = ref.read(valClientProvider);
     valClient.setString(
@@ -48,9 +78,21 @@ class UnitsNotifier extends Notifier<Units> {
       unit == DistanceUnit.kilometers ? "KILOMETERS" : "MILES",
       true,
     );
+    //write to storage API
+    var storageClient = ref.read(storageClientProvider);
+    final userClient = ref.read(usersProvider);
+    try {
+      await storageClient.write(storage_api.KeyValue(
+        key: VSSPath.vehicleHmiDistanceUnit,
+        value: unit == DistanceUnit.kilometers ? 'KILOMETERS' : 'MILES',
+        namespace: userClient.selectedUser.id
+      ));
+    } catch (e) {
+      print('Error saving distance unit: $e');
+    }
   }
 
-  void setTemperatureUnit(TemperatureUnit unit) {
+  Future <void> setTemperatureUnit(TemperatureUnit unit) async{
     state = state.copyWith(temperatureUnit: unit);
     var valClient = ref.read(valClientProvider);
     valClient.setString(
@@ -58,9 +100,21 @@ class UnitsNotifier extends Notifier<Units> {
       unit == TemperatureUnit.celsius ? "C" : "F",
       true,
     );
+    //write to storage API
+    var storageClient = ref.read(storageClientProvider);
+    final userClient = ref.read(usersProvider);
+    try {
+      await storageClient.write(storage_api.KeyValue(
+        key: VSSPath.vehicleHmiTemperatureUnit,
+        value: unit == TemperatureUnit.celsius ? "C" : "F",
+        namespace: userClient.selectedUser.id
+      ));
+    } catch (e) {
+      print('Error saving distance unit: $e');
+    }
   }
 
-  void setPressureUnit(PressureUnit unit) {
+  Future <void> setPressureUnit(PressureUnit unit) async{
     state = state.copyWith(pressureUnit: unit);
     var valClient = ref.read(valClientProvider);
     valClient.setString(
@@ -68,5 +122,17 @@ class UnitsNotifier extends Notifier<Units> {
       unit == PressureUnit.kilopascals ? "KPA" : "PSI",
       true,
     );
+    //write to storage API
+    var storageClient = ref.read(storageClientProvider);
+    final userClient = ref.read(usersProvider);
+    try {
+      await storageClient.write(storage_api.KeyValue(
+        key: VSSPath.vehicleHmiPressureUnit,
+        value: unit == PressureUnit.kilopascals ? "KPA" : "PSI",
+        namespace: userClient.selectedUser.id
+      ));
+    } catch (e) {
+      print('Error saving distance unit: $e');
+    }
   }
 }

--- a/lib/data/data_providers/units_notifier.dart
+++ b/lib/data/data_providers/units_notifier.dart
@@ -9,15 +9,17 @@ class UnitsNotifier extends Notifier<Units> {
     return const Units.initial();
   }
 
+//loads Units state of the selected user from the storage API 
 Future <void> loadSettingsUnits() async{ 
     final storageClient = ref.read(storageClientProvider);
     final userClient = ref.read(usersProvider);
     try {
+      //read unit values from the selected user namespace
       final distanceResponse = await storageClient.read(storage_api.Key(key: VSSPath.vehicleHmiDistanceUnit, namespace: userClient.selectedUser.id));
       final temperatureResponse = await storageClient.read(storage_api.Key(key: VSSPath.vehicleHmiTemperatureUnit, namespace: userClient.selectedUser.id));
       final pressureResponse = await storageClient.read(storage_api.Key(key: VSSPath.vehicleHmiPressureUnit, namespace: userClient.selectedUser.id));
 
-      // Default values
+      // prepare state declaration and fall back to default values if the key isnt present in the storage API
       final distanceUnit = distanceResponse.result == 'MILES'
           ? DistanceUnit.miles
           : DistanceUnit.kilometers;
@@ -33,7 +35,7 @@ Future <void> loadSettingsUnits() async{
       state =  Units(distanceUnit, temperatureUnit, pressureUnit);
     } catch (e) {
       print('Error loading settings for units: $e');
-      state =  const Units.initial(); // Fallback to initial defaults if error
+      state =  const Units.initial(); // Fallback to initial defaults if error occurs
     }
   }
 
@@ -78,7 +80,7 @@ Future <void> loadSettingsUnits() async{
       unit == DistanceUnit.kilometers ? "KILOMETERS" : "MILES",
       true,
     );
-    //write to storage API
+    //write to storage API (selected user namespace)
     var storageClient = ref.read(storageClientProvider);
     final userClient = ref.read(usersProvider);
     try {
@@ -100,7 +102,7 @@ Future <void> loadSettingsUnits() async{
       unit == TemperatureUnit.celsius ? "C" : "F",
       true,
     );
-    //write to storage API
+    //write to storage API (selected user namespace)
     var storageClient = ref.read(storageClientProvider);
     final userClient = ref.read(usersProvider);
     try {
@@ -122,7 +124,7 @@ Future <void> loadSettingsUnits() async{
       unit == PressureUnit.kilopascals ? "KPA" : "PSI",
       true,
     );
-    //write to storage API
+    //write to storage API (selected user namespace)
     var storageClient = ref.read(storageClientProvider);
     final userClient = ref.read(usersProvider);
     try {

--- a/lib/data/data_providers/users_notifier.dart
+++ b/lib/data/data_providers/users_notifier.dart
@@ -118,7 +118,7 @@ Future <void> loadSettingsUsers() async{
     }
     }
     if (state.users.isEmpty) {
-      state = state.copyWith(selectedUser: const User(id: '', name: ''));
+      state = state.copyWith(selectedUser: const User(id: '0', name: ''));
     }
   }
 

--- a/lib/data/data_providers/users_notifier.dart
+++ b/lib/data/data_providers/users_notifier.dart
@@ -4,9 +4,67 @@ import 'package:uuid/uuid.dart';
 
 import '../models/user.dart';
 
-class UsersNotifier extends StateNotifier<Users> {
-  UsersNotifier(super.state) {
+import 'package:protos/storage-api.dart' as storage_api; 
+import 'initializeSettings.dart';
+
+class UsersNotifier extends Notifier<Users> {
+
+  //New build function because of the provider change
+  @override
+  Users build() {
+    // Initialize default state
+    state = Users.initial();
     loadUsers();
+    return state;
+  }
+
+Future <void> loadSettingsUsers() async{
+  final storageClient = ref.read(storageClientProvider);
+    try {
+      //access users branch
+      final searchResponseUsers = await storageClient.search(storage_api.Key(key: VSSPath.vehicleUsers));
+      //add default users if no users are inside the storage API
+      if(searchResponseUsers.result.isEmpty){
+        loadUsers();
+        await storageClient.write(storage_api.KeyValue(key: '${VSSPath.vehicleUsers}.${_users[0].id}.id', value: _users[0].id));
+        await storageClient.write(storage_api.KeyValue(key: '${VSSPath.vehicleUsers}.${_users[0].id}.name', value: _users[0].name));
+        await storageClient.write(storage_api.KeyValue(key: '${VSSPath.vehicleUsers}.${_users[1].id}.id', value: _users[1].id));
+        await storageClient.write(storage_api.KeyValue(key: '${VSSPath.vehicleUsers}.${_users[1].id}.name', value: _users[1].name));
+        await storageClient.write(storage_api.KeyValue(key: '${VSSPath.vehicleUsers}.${_users[2].id}.id', value: _users[2].id));
+        await storageClient.write(storage_api.KeyValue(key: '${VSSPath.vehicleUsers}.${_users[2].id}.name', value: _users[2].name));
+        await selectUser(_users[0].id);
+      }
+      else{        
+        List<User> users = [];
+        List<String> idList = [];
+        //get list of all id's
+        for(var key in searchResponseUsers.result){
+          var readResponse = await storageClient.read(storage_api.Key(key: key)); 
+          if(key.contains('.id')){
+            idList.insert(0, readResponse.result);
+          }
+        }
+        //extract names corresponding to id's
+        for(var id in idList){
+          var readResponse = await storageClient.read(storage_api.Key(key:'${VSSPath.vehicleUsers}.$id.name'));
+          users.insert(0, User(id: id, name: readResponse.result));
+        }
+        //extract id of selected user
+        final readResponseSelectedUser = await storageClient.read(storage_api.Key(key: VSSPath.vehicleCurrentUser));
+        User selectedUser;
+        final userCurrentId =  readResponseSelectedUser.result;
+        //extract name of selected user
+        final readResponseCurrentUserName = await storageClient.read(storage_api.Key(key: '${VSSPath.vehicleUsers}.$userCurrentId.name'));
+        final userCurrentName = readResponseCurrentUserName.result;
+        selectedUser = User(id: userCurrentId, name: userCurrentName);
+        
+        state =  Users(users: users, selectedUser: selectedUser);
+      }
+    }   catch (e) {
+        print('Error loading settings for units: $e');
+        loadUsers(); // Fallback to initial defaults if error
+        state = state.copyWith(selectedUser: _users[0]);
+    } 
   }
 
   void loadUsers() {
@@ -18,27 +76,73 @@ class UsersNotifier extends StateNotifier<Users> {
     const User(id: '2', name: 'George'),
     const User(id: '3', name: 'Riley'),
   ];
-  void selectUser(String userId) {
-    var seletedUser = state.users.firstWhere((user) => user.id == userId);
+  
+  Future <void> selectUser(String userId) async{
+    final storageClient = ref.read(storageClientProvider);
+    var seletedUser = state.users.firstWhere((user) => user.id == userId); //need to loead functions
     state = state.copyWith(selectedUser: seletedUser);
-  }
+    //write to storage API
+    try {
+      await storageClient.write(storage_api.KeyValue(
+        key: VSSPath.vehicleCurrentUser,
+        value: userId,
+      ));
+    } catch (e) {
+      print('Error saving user: $e');
+    }
+    
+    try {
+      await initializeSettingsUser(ref);
+    } catch (e) {
+      print('Error loading settings of user: $e');
+    }
+    
+  }  
 
-  void removeUser(String userId) {
+  Future <void> removeUser(String userId) async{
+    final storageClient = ref.read(storageClientProvider);
     state.users.removeWhere((user) => user.id == userId);
     if (state.users.isNotEmpty) {
       state = state.copyWith(selectedUser: state.users.first);
+      //delete from storage API
+      try {
+        final searchResponse = await storageClient.search(storage_api.Key(key: userId));
+        final keyList = searchResponse.result;
+        for(final key in keyList){       
+          await storageClient.delete(storage_api.Key(
+          key: key
+        ));}
+
+    } catch (e) {
+      print('Error removing user with id $userId: $e');
+    }
     }
     if (state.users.isEmpty) {
       state = state.copyWith(selectedUser: const User(id: '', name: ''));
     }
   }
 
-  void addUser(String userName) {
+  Future <void> addUser(String userName) async{
+    final storageClient = ref.read(storageClientProvider);
     final id = const Uuid().v1();
     final user = User(id: id, name: userName);
 
     state.users.insert(0, user);
-    state = state.copyWith(selectedUser: state.users.first);
+    //new user automaticaly selected
+    await selectUser(user.id); 
+    //write to storage API
+    try {
+      await storageClient.write(storage_api.KeyValue(
+        key: '${VSSPath.vehicleUsers}.$id.name',
+        value: userName
+      ));
+      await storageClient.write(storage_api.KeyValue(
+        key: '${VSSPath.vehicleUsers}.$id.id',
+        value: id
+      ));
+  } catch (e) {
+      print('Error adding user with id $id: $e');
+    }
   }
 
   void editUser(User user) {

--- a/lib/data/models/users.dart
+++ b/lib/data/models/users.dart
@@ -16,7 +16,7 @@ class Users {
   Users.initial()
       //: users = <User>[],
       : users = [],
-        selectedUser = const User(id: '', name: '');
+        selectedUser = const User(id: '0', name: '');
 
   Users copyWith({
     List<User>? users,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,15 @@
 import 'package:device_preview/device_preview.dart';
 
 import 'export.dart';
+import 'data/data_providers/initializeSettings.dart'; //new
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  //initialize settings from storage API
+  final container = ProviderContainer();
+  initializeSettings(container);
+
   runApp(DevicePreview(
     enabled: debugDisplay,
     tools: const [

--- a/test/StorageClient_test.dart
+++ b/test/StorageClient_test.dart
@@ -232,6 +232,14 @@ void main() {
       await storageClient.destroyDB();
     });
 
+    test('read non-existent key', () async{
+      await storageClient.destroyDB();
+      final writeResponse = await storageClient.read(storage_api.Key(key: 'Key.Absent'));
+      expect(writeResponse.success, isFalse);
+      expect(writeResponse.result, '');
+      await storageClient.destroyDB();
+    });
+
     //Search
     test('search substring: Vehicle.Infotainment.Radio', () async {
     await prepareTree();

--- a/test/storageAPI_UnitsForUsers_test.dart
+++ b/test/storageAPI_UnitsForUsers_test.dart
@@ -1,0 +1,291 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:protos/storage-api.dart' as storage_api;
+import 'package:flutter_ics_homescreen/export.dart';
+
+import 'package:flutter_ics_homescreen/data/data_providers/storage_client.dart';
+import 'package:flutter_ics_homescreen/data/data_providers/initializeSettings.dart';
+
+
+// Mock implementation of Ref if necessary
+class MockRef extends Ref {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  late StorageClient storageClient;
+  late ProviderContainer container;
+  
+  setUp(() {
+    storageClient = StorageClient(
+      config: StorageConfig.defaultConfig(),
+      ref: MockRef(),
+    );
+    container = ProviderContainer();
+    //dispose container after each test
+    addTearDown(container.dispose);
+  });
+
+  test('add User', () async {
+    await storageClient.destroyDB();
+    final userClient = container.read(usersProvider.notifier);
+    await userClient.addUser('Mark');
+    //access state
+    var userState = container.read(usersProvider);
+    final userId = userState.users[0].id;
+    final searchResponse = await storageClient.read(storage_api.Key(key: '${VSSPath.vehicleUsers}.$userId.name'));
+    expect(searchResponse.success, isTrue);
+    expect(searchResponse.result, 'Mark');
+    await storageClient.destroyDB();
+  });
+
+  test('remove User', () async{
+    await storageClient.destroyDB();
+    //add User
+    final userClient = container.read(usersProvider.notifier);
+    await userClient.addUser('Mark');
+    //access state
+    var userState = container.read(usersProvider);
+    final markId = userState.users[0].id;
+
+    //remove User
+    await userClient.removeUser(markId);
+    final searchResponse = await storageClient.search(storage_api.Key(key: markId));
+    expect(searchResponse.success, isTrue);
+    expect(searchResponse.result, []);
+    await storageClient.destroyDB();
+  });
+
+  test('add users, select user', () async{
+    await storageClient.destroyDB();
+    //add Users
+    final userClient = container.read(usersProvider.notifier);
+    await userClient.addUser('Mark');
+    await userClient.addUser('Clara');
+
+    var userState = container.read(usersProvider);
+    final markId = userState.users[1].id;
+    await userClient.selectUser(markId);
+
+    final readResponseAfterSelectUser = await storageClient.read(storage_api.Key(key: VSSPath.vehicleCurrentUser));
+    expect(readResponseAfterSelectUser.success, isTrue);
+    expect(readResponseAfterSelectUser.result, markId);
+    await storageClient.destroyDB();
+  });
+
+    test('selected user default', () async{
+    await storageClient.destroyDB();
+
+    //access state
+    var userState = container.read(usersProvider);
+    final selectedId = userState.selectedUser.id;
+
+    final readResponse = await storageClient.read(storage_api.Key(key: VSSPath.vehicleCurrentUser));
+    expect(readResponse.success, isFalse);
+    expect(selectedId, '');
+    await storageClient.destroyDB();
+  });
+
+  test('save Unit preference for a User', () async{
+    await storageClient.destroyDB();
+    //add Users
+    final userClient = container.read(usersProvider.notifier);
+    final unitsClient = container.read(unitStateProvider.notifier);
+    await userClient.addUser('Mark');
+    await userClient.addUser('Clara');
+
+    var userState = container.read(usersProvider);
+    final markId = userState.users[1].id;
+    await userClient.selectUser(markId);
+
+    await unitsClient.setDistanceUnit(DistanceUnit.miles);
+
+    final readResponse = await storageClient.read(storage_api.Key(key: VSSPath.vehicleHmiDistanceUnit, namespace: markId));
+    expect(readResponse.success, isTrue);
+    expect(readResponse.result, 'MILES');
+    await storageClient.destroyDB();
+  });
+
+  test('load settings: add users, selcect user, setDistanceUnit, kill state,  initialize', () async{
+    await storageClient.destroyDB();
+
+    //clients
+    final userClient = container.read(usersProvider.notifier);
+    final unitsClient = container.read(unitStateProvider.notifier);
+
+    //prepare state
+    await userClient.addUser('Mark');
+    await userClient.addUser('Clara');
+    var userState = container.read(usersProvider);
+    final markId = userState.users[1].id;
+    await userClient.selectUser(markId);
+    await unitsClient.setDistanceUnit(DistanceUnit.miles);
+
+    //check success
+    var unitState = container.read(unitStateProvider);
+    userState = container.read(usersProvider);
+    expect(userState.users[0].name, 'Clara');
+    expect(userState.users[1].name, 'Mark');
+    expect(userState.users.length, 5);
+    expect(userState.selectedUser.id, markId);
+    expect(unitState.distanceUnit, DistanceUnit.miles);
+    
+    //killing state
+    container.dispose();
+    container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    //check that state is killed
+    userState = container.read(usersProvider);
+    unitState = container.read(unitStateProvider);
+    expect(userState.selectedUser.id, '');
+    expect(unitState.distanceUnit, DistanceUnit.kilometers);
+
+    //load state
+    await initializeSettings(container);
+    
+    //check success
+    unitState = container.read(unitStateProvider);
+    userState = container.read(usersProvider); 
+    expect(userState.selectedUser.id, markId);
+    List<String> userNames = userState.users.map((user) => user.name).toList();
+    expect(userNames.contains('Mark'), isTrue);
+    expect(userNames.contains('Clara'), isTrue);
+    expect(userState.users.length, 2);
+    expect(unitState.distanceUnit, DistanceUnit.miles);
+  
+    await storageClient.destroyDB();
+  });
+
+  test('loadsettings: add users, setDistanceUnit, kill state, initialize', () async{
+    await storageClient.destroyDB();
+
+    //clients
+    final userClient = container.read(usersProvider.notifier);
+    final unitsClient = container.read(unitStateProvider.notifier);
+
+    //prepare state
+    await userClient.addUser('Mark');
+    await userClient.addUser('Clara');
+    var userState = container.read(usersProvider);
+    final claraId = userState.users[0].id;
+    await unitsClient.setDistanceUnit(DistanceUnit.miles);
+
+    //check success
+    var unitState = container.read(unitStateProvider);
+    userState = container.read(usersProvider);
+    expect(userState.users[0].name, 'Clara');
+    expect(userState.users[1].name, 'Mark');
+    expect(userState.selectedUser.id, claraId);
+    expect(unitState.distanceUnit, DistanceUnit.miles);
+    
+    //killing state
+    container.dispose();
+    container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    //check that state is killed
+    userState = container.read(usersProvider);
+    unitState = container.read(unitStateProvider);
+    expect(userState.selectedUser.id, '');
+    expect(unitState.distanceUnit, DistanceUnit.kilometers);
+
+    //load state
+    await initializeSettings(container);
+    
+    //check success
+    unitState = container.read(unitStateProvider);
+    userState = container.read(usersProvider); 
+    expect(userState.selectedUser.id, claraId);
+    List<String> userNames = userState.users.map((user) => user.name).toList();
+    expect(userNames.contains('Mark'), isTrue);
+    expect(userNames.contains('Clara'), isTrue);
+    expect(unitState.distanceUnit, DistanceUnit.miles);
+  
+    await storageClient.destroyDB();
+  });
+
+  test('loadsettings: initialize, add no user, setDistanceUnit, kill state, inizialize', () async{
+    await storageClient.destroyDB();
+    await initializeSettings(container);
+
+    var userState = container.read(usersProvider);
+    var readResponse = await storageClient.read(storage_api.Key(key: '${VSSPath.vehicleUsers}.1.name'));
+    expect(readResponse.result, 'Heather');
+
+    //clients
+    final unitsClient = container.read(unitStateProvider.notifier);
+
+    //prepare state
+    userState = container.read(usersProvider);
+    await unitsClient.setDistanceUnit(DistanceUnit.miles);
+
+    //check success
+    var unitState = container.read(unitStateProvider);
+    userState = container.read(usersProvider);
+    expect(userState.users[0].name, 'Heather');
+    expect(unitState.distanceUnit, DistanceUnit.miles); 
+    expect(userState.selectedUser.id, '1');
+    
+    //killing state
+    container.dispose();
+    container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    //check that state is killed
+    userState = container.read(usersProvider);
+    unitState = container.read(unitStateProvider);
+    expect(userState.selectedUser.id, '');
+    expect(unitState.distanceUnit, DistanceUnit.kilometers);
+
+    //load state
+    await initializeSettings(container);
+    
+    //check success
+    unitState = container.read(unitStateProvider);
+    userState = container.read(usersProvider); 
+    expect(userState.users[0].name, 'Heather');
+    expect(unitState.distanceUnit, DistanceUnit.miles);
+    expect(userState.selectedUser.name, 'Heather');
+  
+    await storageClient.destroyDB();
+  });
+
+  test('select user: load settings', () async{
+    await storageClient.destroyDB();
+    //clients
+    final userClient = container.read(usersProvider.notifier);
+    final unitsClient = container.read(unitStateProvider.notifier);
+    //prepare state
+    await userClient.addUser('Mark');
+    await userClient.addUser('Clara');
+    var userState = container.read(usersProvider);
+    final claraId = userState.users[0].id;
+    final markId = userState.users[1].id;
+    //Note: Current user Clara
+    await unitsClient.setDistanceUnit(DistanceUnit.miles);
+    await unitsClient.setTemperatureUnit(TemperatureUnit.fahrenheit);
+    await unitsClient.setPressureUnit(PressureUnit.psi);
+  
+    await userClient.selectUser(markId);
+    await unitsClient.setDistanceUnit(DistanceUnit.miles);
+    await unitsClient.setTemperatureUnit(TemperatureUnit.celsius);
+    await unitsClient.setPressureUnit(PressureUnit.kilopascals);
+  
+    await userClient.selectUser(claraId);
+    var unitState = container.read(unitStateProvider);
+    expect(unitState.distanceUnit, DistanceUnit.miles);
+    expect(unitState.temperatureUnit, TemperatureUnit.fahrenheit);
+    expect(unitState.pressureUnit, PressureUnit.psi);
+  
+    var readResponse = await storageClient.read(storage_api.Key(key: VSSPath.vehicleHmiDistanceUnit, namespace: claraId));
+    expect(readResponse.result, 'MILES');
+    readResponse = await storageClient.read(storage_api.Key(key: VSSPath.vehicleHmiTemperatureUnit, namespace: claraId));
+    expect(readResponse.result, 'F');
+    readResponse = await storageClient.read(storage_api.Key(key: VSSPath. vehicleHmiPressureUnit, namespace: claraId));
+    expect(readResponse.result, 'PSI');
+  
+    await storageClient.destroyDB();
+  });
+}
+

--- a/test/storageAPI_UnitsForUsers_test.dart
+++ b/test/storageAPI_UnitsForUsers_test.dart
@@ -82,7 +82,7 @@ void main() {
 
     final readResponse = await storageClient.read(storage_api.Key(key: VSSPath.vehicleCurrentUser));
     expect(readResponse.success, isFalse);
-    expect(selectedId, '');
+    expect(selectedId, '0');
     await storageClient.destroyDB();
   });
 
@@ -138,7 +138,7 @@ void main() {
     //check that state is killed
     userState = container.read(usersProvider);
     unitState = container.read(unitStateProvider);
-    expect(userState.selectedUser.id, '');
+    expect(userState.selectedUser.id, '0');
     expect(unitState.distanceUnit, DistanceUnit.kilometers);
 
     //load state
@@ -187,7 +187,7 @@ void main() {
     //check that state is killed
     userState = container.read(usersProvider);
     unitState = container.read(unitStateProvider);
-    expect(userState.selectedUser.id, '');
+    expect(userState.selectedUser.id, '0');
     expect(unitState.distanceUnit, DistanceUnit.kilometers);
 
     //load state
@@ -235,7 +235,7 @@ void main() {
     //check that state is killed
     userState = container.read(usersProvider);
     unitState = container.read(unitStateProvider);
-    expect(userState.selectedUser.id, '');
+    expect(userState.selectedUser.id, '0');
     expect(unitState.distanceUnit, DistanceUnit.kilometers);
 
     //load state


### PR DESCRIPTION
SDV354,364
feat:  Saving unit settings concerning distance, temperature and pressure inside the API for each user in the namespace=userId. If a unit is changed, the unit gets changed in the storage API inside the namespace of the selected user. 
The loadsettingsUnits function is needed for SDV366. It loads the units of the selected user from the API into the state.

keys:
VSSPath.vehicleHmiDistanceUnit
VSSPath.vehicleHmiTemperatureUnit
VSSPath.vehicleHmiPressureUnit

SDV365,366
feat:
1. Users are saved in the default namespace:

keys:
'${VSSPath.vehicleUsers}.$userId.name'
'${VSSPath.vehicleUsers}.$userId.id'
VSSPath.vehicleCurrentUse


2. Load all users and load unit settings of the selected user at the program start. Load the unit settings of a newly selected user. If no users are inside the storage API, the three default users are written into it and one of them selected as the selectedUser. The default selected user has now the id '0' instead of '' because the default namespace is already reserved for the user keys.
Note: Change of the userProvider to a NotifierProvider 

SDV367
tests: Testing of User/Unit/Initialization Integration (more tests may be needed)


Additionally one test for the storageClient is pushed. It checks if a read-request for a non-existent key is handled properly.

